### PR TITLE
Remove URLSearchPrams to support older browsers

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -9,10 +9,10 @@ const mvkScrollHelper = appContainerNode => {
     return;
   }
 
-  const searchParams = new URLSearchParams(location.search);
+  const isMobileWeb = new RegExp(`[?&]${PLATFORM_PARAM}=${MOBILE_WEB}(&|$)`).test(location.search);
   const { userAgent } = navigator;
 
-  if ((userAgent.includes('iPhone') || userAgent.includes('iPad')) && searchParams.get(PLATFORM_PARAM) === MOBILE_WEB) {
+  if ((userAgent.includes('iPhone') || userAgent.includes('iPad')) && isMobileWeb) {
     appContainerNode.style.overflowY = 'scroll';
     appContainerNode.style.webkitOverflowScrolling = 'touch';
   }

--- a/src/main.js
+++ b/src/main.js
@@ -9,7 +9,7 @@ const mvkScrollHelper = appContainerNode => {
     return;
   }
 
-  const isMobileWeb = new RegExp(`[?&]${PLATFORM_PARAM}=${MOBILE_WEB}(&|$)`).test(location.search);
+  const isMobileWeb = location.search.indexOf(`${PLATFORM_PARAM}=${MOBILE_WEB}`) > -1;
   const { userAgent } = navigator;
 
   if ((userAgent.indexOf('iPhone') > -1 || userAgent.indexOf('iPad') > -1) && isMobileWeb) {

--- a/src/main.js
+++ b/src/main.js
@@ -12,7 +12,7 @@ const mvkScrollHelper = appContainerNode => {
   const isMobileWeb = new RegExp(`[?&]${PLATFORM_PARAM}=${MOBILE_WEB}(&|$)`).test(location.search);
   const { userAgent } = navigator;
 
-  if ((userAgent.includes('iPhone') || userAgent.includes('iPad')) && isMobileWeb) {
+  if ((userAgent.indexOf('iPhone') > -1 || userAgent.indexOf('iPad') > -1) && isMobileWeb) {
     appContainerNode.style.overflowY = 'scroll';
     appContainerNode.style.webkitOverflowScrolling = 'touch';
   }


### PR DESCRIPTION
Closes https://github.com/VKCOM/mvk-mini-apps-scroll-helper/issues/2.
Полифиллы URLSearchParams огромные и излишние по функциональности для текущей задачи